### PR TITLE
Update figWeb.sh

### DIFF
--- a/figWeb.sh
+++ b/figWeb.sh
@@ -305,6 +305,7 @@ function generateHomeLoop #Generate index.html file
 
 		page="<html>
 		<head>
+			<meta charset="utf-8">
 			<title>$nodeName | figWeb</title>
 		</head>
 


### PR DESCRIPTION
Fix UTF-8 characters not displaying correctly

Some devices show `â–‘â–’â–“â–ˆâ”‚` instead of `░▒▓█│` on http://walkman100.ddns.net/

Changing `figWeb/index.html` to include this line fixes the page temporarily.